### PR TITLE
New IVU ophyd device

### DIFF
--- a/startup/11-energy.py
+++ b/startup/11-energy.py
@@ -39,6 +39,7 @@ def energy_to_bragg(target_energy, delta_bragg=0):
     bragg_angle = np.arcsin((ANG_OVER_EV / target_energy) / (2 * D_Si111)) / np.pi * 180 - delta_bragg
     return bragg_angle
 
+
 def wait_all(motors_list, sleep=0.0, debug=False):
     """Wait until the last motor finished movement.
     :param motors_list: the list of all motors to wait.
@@ -54,6 +55,7 @@ def wait_all(motors_list, sleep=0.0, debug=False):
             ttime.sleep(sleep)
         else:
             break
+
 
 def move_dcm(target_energy, delta_bragg=0):
     bragg_angle = energy_to_bragg(target_energy, delta_bragg)
@@ -91,7 +93,7 @@ class Energy(PseudoPositioner):
 
     ivugap = Cpt(InsertionDevice,
                  'SR:C12-ID:G1{IVU:1-Ax:Gap}-Mtr',
-                 read_attrs=['readback'],
+                 read_attrs=['user_readback'],
                  configuration_attrs=[],
                  labels=['mono'])
 
@@ -155,7 +157,7 @@ class Energy(PseudoPositioner):
     @pseudo_position_argument
     def set(self, position):
         energy, = position
-        print(position, self.position)
+        # print(position, self.position)
         if np.abs(energy - self.position[0]) < .01:
             return MoveStatus(self, energy, success=True, done=True)
         return super().set([float(_) for _ in position])

--- a/startup/11-energy.py
+++ b/startup/11-energy.py
@@ -70,7 +70,7 @@ def move_dcm(target_energy, delta_bragg=0):
     print('Bragg angle from PV     : {:.5f}'.format(dcm.bragg.get().user_readback))
 
 
-    
+
 class DCMInternals(Device):
     pitch = Cpt(EpicsMotor, 'XF12ID:m67')
     roll = Cpt(EpicsMotor, 'XF12ID:m68')
@@ -89,10 +89,9 @@ class Energy(PseudoPositioner):
     bragg = Cpt(EpicsMotor, 'XF12ID:m65', read_attrs=['user_readback'], labels=['mono'])
 #    dcmpitch = Cpt(EpicsMotor, 'XF12ID:m67', read_attrs=['readback'])
 
-    ivugap = Cpt(UndulatorGap,
-                 'SR:C12-ID:G1{IVU:1',
+    ivugap = Cpt(InsertionDevice,
+                 'SR:C12-ID:G1{IVU:1-Ax:Gap}-Mtr',
                  read_attrs=['readback'],
-                 #configuration_attrs=['corrfunc_sta', 'corrfunc_dis', 'corrfunc_en'],
                  configuration_attrs=[],
                  labels=['mono'])
 
@@ -113,14 +112,14 @@ class Energy(PseudoPositioner):
         harmonic = self.target_harmonic.get()
         if not harmonic % 2:
             raise RuntimeError('harmonic must be odd')
-        
+
         if energy <= 2050:
             raise ValueError("The energy you entered is too low ({} eV). "
                              "Minimum energy = 2050 eV".format(energy))
         if energy >= 24001:
             raise ValueError('The energy you entered is too high ({} eV). '
                              'Maximum energy = 24000 eV'.format(energy))
-        
+
         # compute where we would move everything to in a perfect world
 
         target_ivu_gap = energy_to_gap(energy, harmonic)
@@ -129,12 +128,12 @@ class Energy(PseudoPositioner):
              if harmonic < 1:
                  raise RuntimeError('can not find a valid gap')
              target_ivu_gap = energy_to_gap(energy, harmonic)
-            
+
         target_bragg_angle = energy_to_bragg(energy)
-        
+
         dcm_offset = 25
         target_dcm_gap = (dcm_offset/2)/np.cos(target_bragg_angle * np.pi / 180)
-        
+
         # sometimes move the crystal gap
         if not self.enabledcmgap.get():
             target_dcm_gap = self.dcmgap.position


### PR DESCRIPTION
Work by @tacaswell, @mrakitin and @dhidas

Tested at the beamline, works fine:
```py
In [4]: RE(bp.scan([pil300KW, pil300kwroi2], energy, 13000, 14000, 11), purpose='DAMA testing of the new IVU device')                                                                         
Transient Scan ID: 137598     Time: 2019-05-13 14:12:31
Persistent Unique Scan ID: '22ef323d-131b-4797-96af-29d888dc18b4'
New stream: 'baseline'
Start-of-run baseline readings:
+--------------------------------+--------------------------------+
|                  energy_energy | 13999.998201498343             |
|                   energy_bragg | 8.134743252805695              |
|                  energy_ivugap | 22999.996                      |
|                    pil1m_pos_x | 1.0007000000000001             |
|                    pil1m_pos_y | -60.0007                       |
|                    pil1m_pos_z | 8300.000702                    |
|                        stage_x | 0.002                          |
|                        stage_y | -6.0                           |
|                        stage_z | 0.005                          |
|                       stage_th | 0.0                            |
|                       stage_ph | -0.001                         |
|                       stage_ch | 0.0                            |
|                            prs | 0.0                            |
|                        piezo_x | 4999.959000000003              |
|                        piezo_y | 6000.441                       |
|                        piezo_z | 5.1840000000001965             |
|                       piezo_th | -0.008978                      |
|                       piezo_ch | -0.003643                      |
+--------------------------------+--------------------------------+
                                                                                                                                                                                              
Subscription value callback exception (EpicsSignalWithRBV(read_pv='XF:12IDC-ES:2{Det:300KW}cam1:ArrayCounter_RBV', name='pil300KW_cam_array_counter', parent='pil300KW_cam', value=41978, timestamp=1557770731.123146, pv_kw={}, auto_monitor=False, string=False, write_pv='XF:12IDC-ES:2{Det:300KW}cam1:ArrayCounter', limits=False, put_complete=False))
Traceback (most recent call last):
  File "/opt/conda_envs/collection-2019-2.0-smi/lib/python3.6/site-packages/ophyd/ophydobj.py", line 269, in inner
    cb(*args, **kwargs)
  File "/opt/conda_envs/collection-2019-2.0-smi/lib/python3.6/site-packages/ophyd/areadetector/trigger_mixins.py", line 64, in _notify_watchers
    time_remaining = time_elapsed / fraction
New stream: 'primary'                                                                                                                                                                         
+-----------+------------+---------------+--------------+---------------+-----------------------+--------------+
|   seq_num |       time | energy_energy | energy_bragg | energy_ivugap | pil300KW_stats1_total | pil300kwroi2 |
+-----------+------------+---------------+--------------+---------------+-----------------------+--------------+
|         1 | 14:13:07.4 |     13000.000 |      8.76524 |       6617.75 |                     0 |           -2 |
|         2 | 14:13:09.9 |     13100.000 |      8.69781 |       6651.11 |                     0 |           -2 |                                                                              
|         3 | 14:13:11.9 |     13199.995 |      8.63141 |       6684.39 |                     0 |            1 |                                                                              
|         4 | 14:13:13.9 |     13300.006 |      8.56602 |       6717.63 |                     0 |           -2 |                                                                              
|         5 | 14:13:15.9 |     13399.999 |      8.50162 |       6750.82 |                     0 |           -2 |                                                                              
|         6 | 14:13:18.0 |     13499.997 |      8.43819 |       6783.96 |                     0 |           -2 |                                                                              
|         7 | 14:13:20.0 |     13600.003 |      8.37569 |       6817.03 |                     0 |           -2 |                                                                              
|         8 | 14:13:22.0 |     13699.995 |      8.31413 |       7255.14 |                     0 |           -2 |                                                                              
|         9 | 14:13:25.1 |     13800.003 |      8.25345 |       6883.00 |                     0 |           -2 |                                                                              
|        10 | 14:13:28.5 |     13900.006 |      8.19366 |       6206.21 |                     0 |           -2 |                                                                              
|        11 | 14:13:30.6 |     13999.998 |      8.13474 |       6234.03 |                     0 |           -2 |                                                                              
+-----------+------------+---------------+--------------+---------------+-----------------------+--------------+
generator scan ['22ef323d'] (scan num: 137598)
/opt/conda_envs/collection-2019-2.0-smi/lib/python3.6/site-packages/bluesky/callbacks/fitting.py:167: RuntimeWarning: invalid value encountered in double_scalars
  for dir in range(input.ndim)]
End-of-run baseline readings:
+--------------------------------+--------------------------------+
|                  energy_energy | 13999.998201498343             |
|                   energy_bragg | 8.134743252805695              |
|                  energy_ivugap | 6234.031                       |
|                    pil1m_pos_x | 1.0007000000000001             |
|                    pil1m_pos_y | -60.0007                       |
|                    pil1m_pos_z | 8300.000702                    |
|                        stage_x | 0.002                          |
|                        stage_y | -6.0                           |
|                        stage_z | 0.005                          |
|                       stage_th | 0.0                            |
|                       stage_ph | -0.001                         |
|                       stage_ch | 0.0                            |
|                            prs | 0.0                            |
|                        piezo_x | 4999.957999999999              |
|                        piezo_y | 6000.4400000000005             |
|                        piezo_z | 5.184999999999491              |
|                       piezo_th | -0.008978                      |
|                       piezo_ch | -0.003643                      |
+--------------------------------+--------------------------------+



Out[4]: ('22ef323d-131b-4797-96af-29d888dc18b4',)
```