### PR TITLE
Amptek exporting: separate .csv file per spectrum

### DIFF
--- a/startup/99-exporting.py
+++ b/startup/99-exporting.py
@@ -1,37 +1,60 @@
+import logging
+import os
+import time as ttime
+
 import numpy as np
 import pandas as pd
-
 from databroker.core import SingleRunCache
 from event_model import RunRouter
 
+logger = logging.getLogger('bluesky')
+logger.setLevel('INFO')
 
-def export_spectra_to_csv(run, file, columns=None):
+
+def export_spectra_to_csv(run, *, dir, common_column, columns):
     """Export spectra to a CSV file based on databroker.v2 run.
 
     Parameters:
     -----------
     run: BlueskyRun
         a BlueskyRun, retrieved such as ``run = db.v2['eac4a441']``
-    file: string or buffer
-        a filename of the target file
+    dir: str
+        a directory where the target files should be saved to
     columns: list or None, optional
         a list of columns to export to the CSV file. If None, all
         columns will be attempted to be exported (must have the same
         dimensions)
-
-    Returns:
-    --------
-    df: pandas.DataFrame
-        the resulted pandas DataFrame with the columns.
     """
     xr = run.primary.read()
     if columns is None:
         columns = list(xr.keys())
-    xr = xr[columns]
-    data = np.vstack(list(xr.data_vars.values())).T
-    df = pd.DataFrame(data=data, columns=columns)
-    df.to_csv(file, index=False)
-    return df
+
+    all_columns = [common_column] + columns
+    xr = xr[all_columns]
+
+    num_events = xr.dims['time']
+
+    before_loop_time = ttime.time()
+    logger.info(f'Start exporting of {num_events} spectra to {dir}')
+    for i in range(num_events):
+        file = os.path.join(dir,
+                            f"{run.metadata['start']['uid']}-{i+1:05d}.csv")
+
+        data = getattr(xr, common_column)[i]
+        for j in range(len(columns)):
+            data = np.vstack([data, getattr(xr, columns[j])[i]])
+        data = data.T
+
+        df = pd.DataFrame(data=data, columns=all_columns)
+
+        start_time = ttime.time()
+        logger.info(f'Exporting data with shape {data.shape} to {file}...')
+        df.to_csv(file, index=False)
+        logger.info(f'Exporting to {file} took '
+                    f'{ttime.time() - start_time:.5f}s\n')
+
+    logger.info(f'Exporting of {num_events} spectra took '
+                f'{ttime.time() - before_loop_time:.5f}s')
 
 
 def factory(name, doc):
@@ -41,11 +64,12 @@ def factory(name, doc):
         if name == "stop":
             run = src.retrieve()
             if 'amptek' in run.metadata['start']['detectors']:
-                export_spectra_to_csv(run, f"/tmp/CSV-export/{run.metadata['start']['uid']}.csv",
-                                      ['amptek_energy_channels', 'amptek_mca_spectrum'])
+                export_spectra_to_csv(run, dir="/tmp/CSV-export/",
+                                      common_column='amptek_energy_channels',
+                                      columns=['amptek_mca_spectrum'])
 
     return [src.callback, export_on_stop], []
 
 
 rr = RunRouter([factory])
-RE.subscribe(rr)
+RE.subscribe(rr)  # noqa F821


### PR DESCRIPTION
This PR solves the issue when all spectra are written into the same file. With this implementation, a separate file is created for each spectrum. I tested it with `rr` as follows:
```py
In [2]: hdr = db['db07b5ea']                                                                        

In [3]: for name, doc in hdr.documents(): 
   ...:     rr(name, doc)
```

I changed the API a bit to require the `common_column`. Also, added the logger, which will write the output to the bluesky log.