### PR TITLE
FIX: enable kafka subscription

### DIFF
--- a/startup/00-base.py
+++ b/startup/00-base.py
@@ -37,9 +37,15 @@ tiled_inserter = TiledInserter()
 
 # The function below initializes RE and subscribes tiled_inserter to it
 nslsii.configure_base(get_ipython().user_ns,
-               tiled_inserter,
+               "smi",
                bec_derivative=True, 
                publish_documents_with_kafka=True)
+
+# This is a workaround to enable us subscribe to Kafka publisher, which requires a beamline acronym when calling
+# configuration_base above (ideally, we would just pass tiled_inserter there).
+# Here we unsubsribe the default databroker (with token=0) and then subscribe the tiled_inserter instead.
+RE.unsubscribe(0)
+RE.subscribe(tiled_inserter.insert)
 
 print("\nInitializing Tiled reading client...\nMake sure you check for duo push.")
 tiled_reading_client = from_profile("nsls2", username=None)["smi"]["raw"]


### PR DESCRIPTION
Adding a workaround to enable `configure_base` subscribe to kafka when the beamline acronym is passed.